### PR TITLE
Add workaround for identifier inconsistency on macOS 12

### DIFF
--- a/AppKitIntegration/AppKitController.swift
+++ b/AppKitIntegration/AppKitController.swift
@@ -14,7 +14,7 @@ extension NSObject {
 
 class AppKitController : NSObject {
 	
-	var preferencesSceneIdentifier:String?
+	private var preferencesSceneIdentifier: UIKitSceneIdentifier?
 	
 	// MARK: -
 	
@@ -28,7 +28,9 @@ class AppKitController : NSObject {
 		*/
 		
 		if let userInfo = note.userInfo, let sceneIdentifier = userInfo["SceneIdentifier"] as? String {
-			if sceneIdentifier == preferencesSceneIdentifier {
+            let appKitSceneIdentifier = AppKitSceneIdentifier(sceneIdentifier)
+            let uiKitSceneIdentifier = UIKitSceneIdentifier(appKitSceneIdentifier)
+			if  uiKitSceneIdentifier == preferencesSceneIdentifier {
 				guard let appDelegate = NSApp.delegate as? NSObject else { return }
 				
 				if appDelegate.responds(to: #selector(hostWindowForSceneIdentifier(_:))) {
@@ -42,6 +44,6 @@ class AppKitController : NSObject {
 	}
 	
 	@objc public func configurePreferencesWindowForSceneIdentifier(_ sceneIdentifier:String) {
-		preferencesSceneIdentifier = sceneIdentifier
+		preferencesSceneIdentifier = UIKitSceneIdentifier(sceneIdentifier)
 	}
 }

--- a/AppKitIntegration/AppKitSceneIdentifier.swift
+++ b/AppKitIntegration/AppKitSceneIdentifier.swift
@@ -1,0 +1,16 @@
+//
+//  AppKitSceneIdentifier.swift
+//  AppKitSceneIdentifier
+//
+//  Created by Simon Støvring on 22/07/2021.
+//
+
+import Foundation
+
+struct AppKitSceneIdentifier: Hashable {
+    let rawValue: String
+
+    init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}

--- a/AppKitIntegration/UIKitSceneIdentifier.swift
+++ b/AppKitIntegration/UIKitSceneIdentifier.swift
@@ -1,0 +1,21 @@
+//
+//  SceneIdentifier.swift
+//  SceneIdentifier
+//
+//  Created by Simon Støvring on 22/07/2021.
+//
+
+import Foundation
+
+struct UIKitSceneIdentifier: Hashable {
+    let rawValue: String
+
+    init(_ rawValue: String) {
+       self.rawValue = rawValue
+    }
+
+    init(_ sceneIdentifier: AppKitSceneIdentifier) {
+        rawValue = sceneIdentifier.rawValue.components(separatedBy: "|").last ?? sceneIdentifier.rawValue
+    }
+}
+

--- a/CatalystPrefsWindow.xcodeproj/project.pbxproj
+++ b/CatalystPrefsWindow.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7219C52626AA119B00CEC73D /* UIKitSceneIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7219C52526AA119B00CEC73D /* UIKitSceneIdentifier.swift */; };
+		7219C52826AA11A800CEC73D /* AppKitSceneIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7219C52726AA11A800CEC73D /* AppKitSceneIdentifier.swift */; };
 		B0885EA6266BB4B400E8312E /* AppKitController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0885EA5266BB4B400E8312E /* AppKitController.swift */; };
 		B0885EAA266BB50E00E8312E /* AppKitIntegration.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = B0885E9D266BB4A800E8312E /* AppKitIntegration.framework */; platformFilter = maccatalyst; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B0A17034266B112400FD93F1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A17033266B112400FD93F1 /* AppDelegate.swift */; };
@@ -44,6 +46,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		7219C52526AA119B00CEC73D /* UIKitSceneIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitSceneIdentifier.swift; sourceTree = "<group>"; };
+		7219C52726AA11A800CEC73D /* AppKitSceneIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitSceneIdentifier.swift; sourceTree = "<group>"; };
 		B0885E9D266BB4A800E8312E /* AppKitIntegration.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AppKitIntegration.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B0885EA0266BB4A800E8312E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B0885EA5266BB4B400E8312E /* AppKitController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppKitController.swift; sourceTree = "<group>"; };
@@ -83,8 +87,10 @@
 		B0885E9E266BB4A800E8312E /* AppKitIntegration */ = {
 			isa = PBXGroup;
 			children = (
-				B0885EA5266BB4B400E8312E /* AppKitController.swift */,
 				B0885EA0266BB4A800E8312E /* Info.plist */,
+				B0885EA5266BB4B400E8312E /* AppKitController.swift */,
+				7219C52726AA11A800CEC73D /* AppKitSceneIdentifier.swift */,
+				7219C52526AA119B00CEC73D /* UIKitSceneIdentifier.swift */,
 			);
 			path = AppKitIntegration;
 			sourceTree = "<group>";
@@ -263,6 +269,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				B0885EA6266BB4B400E8312E /* AppKitController.swift in Sources */,
+				7219C52826AA11A800CEC73D /* AppKitSceneIdentifier.swift in Sources */,
+				7219C52626AA119B00CEC73D /* UIKitSceneIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -310,7 +318,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 2ZDN69KUUV;
+				DEVELOPMENT_TEAM = 8NQFWJHC63;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -341,7 +349,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 2ZDN69KUUV;
+				DEVELOPMENT_TEAM = 8NQFWJHC63;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -487,7 +495,7 @@
 				CODE_SIGN_ENTITLEMENTS = CatalystPrefsWindow/CatalystPrefsWindow.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"CatalystPrefsWindow/Preview Content\"";
-				DEVELOPMENT_TEAM = 2ZDN69KUUV;
+				DEVELOPMENT_TEAM = 8NQFWJHC63;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = CatalystPrefsWindow/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
Really appreciate that you've opened source this solution. I'm using it in one of my upcoming Catalyst apps 😃

I ran into a small issue on macOS 12. It appears that the scene identifier differs between `windowScene.session.persistentIdentifier` and the identifier included in the UISBHSDidCreateWindowForSceneNotification notification.

Here's an example between the two:

- `windowScene.session.persistentIdentifier`: 1013C9AC-9C0C-493C-AE24-0AE09303B465
- `UISBHSDidCreateWindowForSceneNotification `: FUScene|com.highcaffeinecontent.CatalystPrefsWindow(23541)|1013C9AC-9C0C-493C-AE24-0AE09303B465

Therefore the fullscreen options wouldn't be disabled for the preferences window.

The last part of the identifier is the same. I modified AppKitController so it only looks at the latter part of the scene identifier when comparing the scene identifier to the one provided from UIKit. It's not _that_ pretty but it does the job.

Tested on macOS 12 beta 3.